### PR TITLE
Workaround docs.rs build failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,13 @@ winapi = {version = "0.3", features = ["minwindef"] }
 
 [build-dependencies]
 cc = "1.0"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+targets = ["x86_64-pc-windows-msvc"]
+# Docs.rs does not have a C cross compiler for windows. This cfg is set so that
+# build.rs can know that it is in a docs.rs build and skip C compilation.
+#
+# https://github.com/rust-lang/docs.rs/issues/147#issuecomment-389544407
+rustc-args = ["--cfg",  "memory_module_sys_docs_rs"]
+rustdoc-args = ["--cfg", "memory_module_sys_docs_rs"]

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,11 @@
 fn main() {
-    println!("cargo:rerun-if-changed=src/memorymodule.c");
-    println!("cargo:rerun-if-changed=src/memorymodule.h");
+    // Skip C compilation if building on docs.rs.
+    if cfg!(not(memory_module_sys_docs_rs)) {
+        println!("cargo:rerun-if-changed=src/memorymodule.c");
+        println!("cargo:rerun-if-changed=src/memorymodule.h");
 
-    cc::Build::new()
-        .file("src/memorymodule.c")
-        .compile("memorymodule");
+        cc::Build::new()
+            .file("src/memorymodule.c")
+            .compile("memorymodule");
+    }
 }


### PR DESCRIPTION
Docs.rs does not have a C cross compiler for windows. (I have also tried the windows-gnu target, no luck either.)

So don't compile the C code on docs.rs. It's not necessary for the docs anyway.

https://github.com/rust-lang/docs.rs/issues/147#issuecomment-389544407